### PR TITLE
Fedora plugdev-group specificity

### DIFF
--- a/make_fedora_rpm.sh
+++ b/make_fedora_rpm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+version=$1
+release=$2
+if [ ! $version ] || [ ! $release ]; then
+    echo "Usage: $0 <new-version> <release>"
+    exit 1
+fi
+
+source common.sh
+
+SRCDIR=$(rpm --eval '%{_sourcedir}')
+
+curl -L "$repourl/releases/download/v$version/openrazer-$version.tar.xz" -o "$SRCDIR/openrazer-$version.tar.xz"
+rpmbuild -bb --define "rel $release" openrazer.spec

--- a/make_fedora_rpm.sh
+++ b/make_fedora_rpm.sh
@@ -10,6 +10,6 @@ source common.sh
 
 readonly SRCDIR=$(rpm --eval '%{_sourcedir}')
 
-curl -L "$repourl/releases/download/v$version/openrazer-$version.tar.xz" -o "$SRCDIR/openrazer-$version.tar.xz"
+spectool -g -R openrazer.spec
 tar -xOf "$SRCDIR/openrazer-$version.tar.xz" '*/debian/changelog' | ./rpm_changelog.py > "$SRCDIR/openrazer-$version.changelog"
-rpmbuild -bb --define "rel $release" openrazer.spec
+rpmbuild -bb --define "rel $release" --with=changelog openrazer.spec

--- a/make_fedora_rpm.sh
+++ b/make_fedora_rpm.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-
 version=$1
 release=$2
-if [ ! $version ] || [ ! $release ]; then
+if [ ! "$version" ] || [ ! "$release" ]; then
     echo "Usage: $0 <new-version> <release>"
     exit 1
 fi
 
 source common.sh
 
-SRCDIR=$(rpm --eval '%{_sourcedir}')
+readonly SRCDIR=$(rpm --eval '%{_sourcedir}')
 
 curl -L "$repourl/releases/download/v$version/openrazer-$version.tar.xz" -o "$SRCDIR/openrazer-$version.tar.xz"
+tar -xOf "$SRCDIR/openrazer-$version.tar.xz" '*/debian/changelog' | ./rpm_changelog.py > "$SRCDIR/openrazer-$version.changelog"
 rpmbuild -bb --define "rel $release" openrazer.spec

--- a/openrazer.spec
+++ b/openrazer.spec
@@ -186,7 +186,7 @@ echo -e "\e[31;1m* # su -c 'usermod -aGinput <yourUsername>'*"
 echo -e "\e[31;1m* # sudo gpasswd -a <yourUsername> input *"
 %endif
 echo -e "\e[31;1m********************************************"
-echo -e -n "\e[39m"
+echo -e -n "\e[39;0m"
 
 
 %preun -n openrazer-kernel-modules-dkms

--- a/openrazer.spec
+++ b/openrazer.spec
@@ -3,13 +3,13 @@
 %define dkms_name openrazer-driver
 %define dkms_version 2.5.0
 
+%{!?rel: %define rel 1}
 #define gitcommit 6ae1f7d55bf10cc6b5cb62a5ce99ff22c43e0701
 
 Name: openrazer-meta
 Version: 2.5.0
-Release: 1%{?dist}
+Release: %{rel}%{?gitcommit:.%(tag="%{gitcommit}"; echo "${tag:0:7}")}%{?dist}
 Summary: Open source driver and user-space daemon for managing Razer devices
-
 License: GPL-2.0
 URL: https://github.com/openrazer/openrazer
 

--- a/openrazer.spec
+++ b/openrazer.spec
@@ -145,7 +145,6 @@ done
 %build
 # noop
 
-
 %install
 rm -rf $RPM_BUILD_ROOT
 # setup_dkms & udev_install -> razer-kernel-modules-dkms
@@ -156,7 +155,6 @@ make DESTDIR=$RPM_BUILD_ROOT setup_dkms udev_install daemon_install python_libra
 %clean
 rm -rf $RPM_BUILD_ROOT
 
-
 %pre -n openrazer-kernel-modules-dkms
 #!/bin/sh
 set -e
@@ -166,55 +164,45 @@ getent group plugdev >/dev/null || groupadd -r plugdev
 %endif
 
 
-%if 0%{?mageia}
-
 %post -n openrazer-kernel-modules-dkms
+#!/bin/sh
+%if 0%{?mageia}
 dkms add -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
 dkms build -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
 dkms install -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
-
-echo -e "\e[31m********************************************"
-echo -e "\e[31m* To complete installation, please run:    *"
-%if 0%{fedora}
-echo -e "\e[31m* # su -c 'usermod -aGinput <yourUsername>'*"
 %else
-echo -e "\e[31m* # sudo gpasswd -a <yourUsername> input *"
-%endif
-echo -e "\e[31m********************************************"
-echo -e -n "\e[39m"
-
-
-%preun -n openrazer-kernel-modules-dkms
-dkms remove -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade --all
-
-%else
-
-%post -n openrazer-kernel-modules-dkms
-#!/bin/sh
 set -e
-
 # Only on initial installation
 if [ "$1" == 1 ]; then
   dkms install %{dkms_name}/%{dkms_version}
 fi
-
 %endif
 
-echo -e "\e[31m********************************************"
-echo -e "\e[31m* To complete installation, please run:    *"
-echo -e "\e[31m* # sudo gpasswd -a <yourUsername> plugdev *"
-echo -e "\e[31m********************************************"
+echo -e "\e[31;1m********************************************"
+echo -e "\e[31;1m* To complete installation, please run:    *"
+%if 0%{fedora}
+echo -e "\e[31;1m* # su -c 'usermod -aGinput <yourUsername>'*"
+%else
+echo -e "\e[31;1m* # sudo gpasswd -a <yourUsername> input *"
+%endif
+echo -e "\e[31;1m********************************************"
 echo -e -n "\e[39m"
+
 
 %preun -n openrazer-kernel-modules-dkms
 #!/bin/sh
 
+%if 0%{?mageia}
+dkms remove -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade --all
+%else
 # Only on uninstallation
 if [ "$1" == 0 ]; then
   if [ "$(dkms status -m %{dkms_name} -v %{dkms_version})" ]; then
     dkms remove -m %{dkms_name} -v %{dkms_version} --all
   fi
 fi
+%endif
+
 
 %files
 # meta package is empty

--- a/openrazer.spec
+++ b/openrazer.spec
@@ -36,8 +36,10 @@ Requires: openrazer-daemon
 Requires: python3-openrazer
 
 %description
-Meta package for installing all required openrazer packages.
+OpenRazer is a collection of GNU/Linux drivers for the Razer devices.
+Supported devices include keyboards, mice, mouse-mats, headsets and various other devices.
 
+This package is a metapackage which depends on the OpenRazer driver and userspace daemon and a Python library.
 
 %package -n openrazer-kernel-modules-dkms
 Summary: OpenRazer Driver DKMS package
@@ -54,8 +56,10 @@ Requires(post): dkms
 Requires(pre): shadow-utils
 %endif
 %description -n openrazer-kernel-modules-dkms
-Kernel driver for Razer devices (DKMS-variant)
-
+OpenRazer is a collection of GNU/Linux drivers for the Razer devices.
+Supported devices include keyboards, mice, mouse-mats, headsets and various other devices.
+ 
+This package provides the source code for the OpenRazer kernel module to be build with dkms. Kernel sources or headers are required to compile this module.
 
 %package -n openrazer-daemon
 Summary: OpenRazer Service package
@@ -84,8 +88,11 @@ Requires: python3-daemonize
 Requires: xautomation
 Requires: xdotool
 %description -n openrazer-daemon
-Userspace daemon that abstracts access to the kernel driver. Provides a DBus service for applications to use.
-
+OpenRazer is a collection of GNU/Linux drivers for the Razer devices.
+Supported devices include keyboards, mice, mouse-mats, headsets and various other devices.
+ 
+This package provides a user-space daemon used to interface with the driver.
+Provides a DBus service for applications to use.
 
 %package -n python3-openrazer
 Summary: OpenRazer Python library
@@ -109,8 +116,10 @@ Requires: python3-gobject
 %endif
 Requires: python3-numpy
 %description -n python3-openrazer
-Python library for accessing the daemon from Python.
-
+OpenRazer is a collection of GNU/Linux drivers for the Razer devices.
+Supported devices include keyboards, mice, mouse-mats, headsets and various other devices.
+ 
+This package contains a library for interacting with the OpenRazer daemon.
 
 %prep
 %if 0%{?_build_in_place:1}

--- a/openrazer.spec
+++ b/openrazer.spec
@@ -3,6 +3,9 @@
 # Builds rpms from sources located at current directory, 
 # postfix with 'local' text will be added to version
 # Usage example: rpmbuild --build-in-place -bb ../OBS-packaging/openrazer.spec
+#
+#      --with=changelog
+# Attach to rpm packages changelog from file openrazer-'version'.changelog
 
 ### Defines (--define 'name value')
 # rel          - set release prefix (default '1')
@@ -15,6 +18,7 @@
 
 %{!?rel: %define rel 1}
 #define gitcommit 6ae1f7d55bf10cc6b5cb62a5ce99ff22c43e0701
+%bcond_with changelog
 
 Name: openrazer-meta
 Version: 2.5.0
@@ -239,4 +243,4 @@ fi
 %{python3_sitelib}/openrazer-*.egg-info/
 
 %changelog
-%{!?_build_in_place: %include %{_sourcedir}/openrazer-%{version}.changelog}
+%{?with_changelog: %include %{_sourcedir}/openrazer-%{version}.changelog}

--- a/rpm_changelog.py
+++ b/rpm_changelog.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+# Convert deb changelog to rpm one
+#
+#from:
+#razer (1.1.15-0ubuntu1) xenial; urgency=high
+#  * Added Device - Razer Orochi 2013
+# -- Terry Cain <terry@terrys-home.co.uk>  Sat, 30 Jul 2017 16:12:00 +0000
+#to
+#* Sat 30 Jul 2017 Terry Cain <terry@terrys-home.co.uk> - 1.1.15-0ubuntu1
+#- Added Device - Razer Orochi 2013
+#- Added Device - Razer Kraken 7.1 Classic
+
+# vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab colorcolumn=76 :
+import string
+from datetime import datetime
+from dateutil import parser
+from dateutil import tz
+import sys
+import re
+
+items = {
+  'header': re.compile(r'^\w+\W*\(([0-9]+[^)]+)\)'),
+  'tail': re.compile(r'--\W+(.+<.+>)\W+(.+)'),
+  'item': re.compile(r'\W+\*\W+(.*)$')
+}
+
+version = None
+author = None
+date = None
+changes = []
+
+def apply():
+  global version
+  global author
+  global date
+  global changes
+  if ((date is not None) and (author is not None) and (version is not None)):
+    if (0>=len(changes)):
+      changes.append('Changelog available at site')
+
+    dt = date.strftime('%a %b %d %Y')
+    print(f'* {dt} {author} - {version}');
+    for item in changes:
+      print(f'- {item}');
+    print('')
+
+  version = None
+  author = None
+  timestamp = None
+  changes.clear()
+
+for line in sys.stdin:
+  line =  line.rstrip()
+  if (not line):
+    continue
+
+  match = None
+  typ = None
+
+  for t,r in items.items():
+    match = r.search(line)
+    if match:
+      typ = t;
+      break
+
+  if (typ == 'header'):
+    apply()
+    version=match[1]
+  elif (typ == 'item'):
+    changes.append(match[1])
+  elif (typ == 'tail'):
+    date = parser.parse(match[2])
+    author = match[1]
+apply()

--- a/rpm_changelog.py
+++ b/rpm_changelog.py
@@ -1,16 +1,15 @@
 #!/usr/bin/python3
 # Convert deb changelog to rpm one
 #
-#from:
-#razer (1.1.15-0ubuntu1) xenial; urgency=high
+# from:
+# razer (1.1.15-0ubuntu1) xenial; urgency=high
 #  * Added Device - Razer Orochi 2013
 # -- Terry Cain <terry@terrys-home.co.uk>  Sat, 30 Jul 2017 16:12:00 +0000
-#to
+# to
 #* Sat 30 Jul 2017 Terry Cain <terry@terrys-home.co.uk> - 1.1.15-0ubuntu1
 #- Added Device - Razer Orochi 2013
 #- Added Device - Razer Kraken 7.1 Classic
 
-# vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab colorcolumn=76 :
 import string
 from datetime import datetime
 from dateutil import parser
@@ -19,9 +18,9 @@ import sys
 import re
 
 items = {
-  'header': re.compile(r'^\w+\W*\(([0-9]+[^)]+)\)'),
-  'tail': re.compile(r'--\W+(.+<.+>)\W+(.+)'),
-  'item': re.compile(r'\W+\*\W+(.*)$')
+    'header': re.compile(r'^\w+\W*\(([0-9]+[^)]+)\)'),
+    'tail': re.compile(r'--\W+(.+<.+>)\W+(.+)'),
+    'item': re.compile(r'\W+\*\W+(.*)$')
 }
 
 version = None
@@ -29,46 +28,50 @@ author = None
 date = None
 changes = []
 
+
 def apply():
-  global version
-  global author
-  global date
-  global changes
-  if ((date is not None) and (author is not None) and (version is not None)):
-    if (0>=len(changes)):
-      changes.append('Changelog available at site')
+    global version
+    global author
+    global date
+    global changes
+    if ((date is not None) and (author is not None) and (version is not None)):
+        if (0 >= len(changes)):
+            changes.append('Changelog available at site')
 
-    dt = date.strftime('%a %b %d %Y')
-    print(f'* {dt} {author} - {version}');
-    for item in changes:
-      print(f'- {item}');
-    print('')
+        dt = date.strftime('%a %b %d %Y')
+        print(f'* {dt} {author} - {version}')
+        for item in changes:
+            print(f'- {item}')
+        print('')
 
-  version = None
-  author = None
-  timestamp = None
-  changes.clear()
+    version = None
+    author = None
+    timestamp = None
+    changes.clear()
+
 
 for line in sys.stdin:
-  line =  line.rstrip()
-  if (not line):
-    continue
+    line = line.rstrip()
+    if (not line):
+        continue
 
-  match = None
-  typ = None
+    match = None
+    typ = None
 
-  for t,r in items.items():
-    match = r.search(line)
-    if match:
-      typ = t;
-      break
+    for t, r in items.items():
+        match = r.search(line)
+        if match:
+            typ = t
+            break
 
-  if (typ == 'header'):
-    apply()
-    version=match[1]
-  elif (typ == 'item'):
-    changes.append(match[1])
-  elif (typ == 'tail'):
-    date = parser.parse(match[2])
-    author = match[1]
+    if (typ == 'header'):
+        apply()
+        version = match[1]
+    elif (typ == 'item'):
+        changes.append(match[1])
+    elif (typ == 'tail'):
+        date = parser.parse(match[2])
+        author = match[1]
+
+# add remained block
 apply()


### PR DESCRIPTION
Fedora uses 'input' group instead 'plugdev' for input devices.