### PR TITLE
Add KMP package and some cleanup

### DIFF
--- a/openrazer.spec
+++ b/openrazer.spec
@@ -69,6 +69,15 @@ BuildArch:      noarch
 %description -n openrazer-meta
 Meta package for installing all required openrazer packages.
 
+%package -n openrazer-udev
+Summary:        Open source driver and user-space daemon for managing Razer devices - udev rules
+BuildArch:      noarch
+%description -n openrazer-udev
+A collection of Linux drivers for Razer devices - providing kernel drivers,
+DBus services and Python bindings to interact with the DBus interface.
+
+udev rules to set proper permissions.
+
 %if %{without openrazer_kmp}
 
 %package -n openrazer-kernel-modules-dkms
@@ -79,6 +88,7 @@ Obsoletes:      razer-kernel-modules-dkms
 Provides:       razer-kernel-modules-dkms
 Requires:       dkms
 Requires:       make
+Requires:       openrazer-udev = %{version}
 # OBS fails without that
 #
 # actually this requires needs to be there at runtime as well because a requires
@@ -262,11 +272,13 @@ fi
 
 %endif
 
-%files -n openrazer-daemon
+%files -n openrazer-udev
 # A bit hacky but it works
 %{_udevrulesdir}/../razer_mount
 %{_udevrulesdir}/99-razer.rules
 #
+
+%files -n openrazer-daemon
 %{_bindir}/openrazer-daemon
 %{python3_sitelib}/openrazer_daemon/
 %{python3_sitelib}/openrazer_daemon-*.egg-info/

--- a/openrazer.spec
+++ b/openrazer.spec
@@ -1,107 +1,156 @@
 # This spec file should work on Fedora, openSUSE and Mageia
+#
+# for kmp builds to get signed kernel modules
+#
+# needssslcertforbuild
 
 %define dkms_name openrazer-driver
 %define dkms_version 3.1.0
 
+%if 0%{?suse_version}
+%define openrazer_driver_package openrazer-kmp
+%bcond_without openrazer_kmp
+%else
+%define openrazer_driver_package openrazer-kernel-modules-dkms
+%bcond_with    openrazer_kmp
+%endif
+
 #define gitcommit 6ae1f7d55bf10cc6b5cb62a5ce99ff22c43e0701
 
-Name: openrazer-meta
-Version: 3.1.0
-Release: 1%{?dist}
-Summary: Open source driver and user-space daemon for managing Razer devices
+Name:           openrazer
+Version:        3.1.0
+Release:        1%{?dist}
+Summary:        Open source driver and user-space daemon for managing Razer devices
 
-License: GPL-2.0
-URL: https://github.com/openrazer/openrazer
+License:        GPL-2.0
+URL:            https://github.com/openrazer/openrazer
 
 %if 0%{?gitcommit:1}
-Source0: https://github.com/openrazer/openrazer/archive/%{gitcommit}.tar.gz
+Source0:        https://github.com/openrazer/openrazer/archive/%{gitcommit}.tar.gz
 %else
-Source0: https://github.com/openrazer/openrazer/releases/download/v%{version}/openrazer-%{version}.tar.xz
+Source0:        https://github.com/openrazer/openrazer/releases/download/v%{version}/openrazer-%{version}.tar.xz
 %endif
 
-BuildArch: noarch
+# preamble file for the kmp
+Source1:        preamble
 
-Requires: openrazer-kernel-modules-dkms
-Requires: openrazer-daemon
-Requires: python3-openrazer
+# directory ownership of the udev files
+BuildRequires:  pkgconfig(systemd)
+# building and installing the python part
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+
+%if %{with openrazer_kmp}
+
+BuildRequires:  %{kernel_module_package_buildreqs}
+
+# setup subpackages for the different kmp packages
+%if 0%{?is_opensuse}
+%kernel_module_package -p %{_sourcedir}/preamble
+%else
+%kernel_module_package -c %_sourcedir/_projectcert.crt -p %{_sourcedir}/preamble
+%endif
+
+%endif
 
 %description
+A collection of Linux drivers for Razer devices - providing kernel drivers,
+DBus services and Python bindings to interact with the DBus interface.
+
+# after renaming the main package back to openrazer, set up a new meta package
+%package -n openrazer-meta
+Summary:        Open source driver and user-space daemon for managing Razer devices
+
+# remove dkms requires here as it is handled in openrazer-daemon
+Requires:       openrazer-daemon
+Requires:       python3-openrazer
+
+BuildArch:      noarch
+%description -n openrazer-meta
 Meta package for installing all required openrazer packages.
 
+%if %{without openrazer_kmp}
 
 %package -n openrazer-kernel-modules-dkms
-Summary: OpenRazer Driver DKMS package
-Group: System Environment/Kernel
-Obsoletes: razer-kernel-modules-dkms
-Provides: razer-kernel-modules-dkms
-Requires: dkms
-Requires: make
-Requires: udev
+Requires:       python3-openrazer
+Summary:        OpenRazer Driver DKMS package
+Group:          System Environment/Kernel
+Obsoletes:      razer-kernel-modules-dkms
+Provides:       razer-kernel-modules-dkms
+Requires:       dkms
+Requires:       make
 # OBS fails without that
-%if 0%{?suse_version}
-Requires(pre): shadow
+#
+# actually this requires needs to be there at runtime as well because a requires
+# does not mean that the package is already or still around when those scriptlets run
+# Requires only means "at the end of the installation we want dkms, Requires(post) means
+# we need dkms when finishing this installation.
+#
 Requires(post): dkms
-%else
-Requires(pre): shadow-utils
-%endif
+Requires(preun): dkms
+Requires(post): make
+Requires(preun): make
 
 %description -n openrazer-kernel-modules-dkms
 Kernel driver for Razer devices (DKMS-variant)
 
+%endif
 
 %package -n openrazer-daemon
-Summary: OpenRazer Service package
-Group: System Environment/Daemons
-Obsoletes: razer-daemon
-Provides: razer-daemon
-BuildRequires: python3-devel
-BuildRequires: python3-setuptools
-Requires: openrazer-kernel-modules-dkms
-Requires: python3
+Summary:        OpenRazer Service package
+Group:          System Environment/Daemons
+BuildArch:      noarch
+Obsoletes:      razer-daemon
+Provides:       razer-daemon
+Requires:       %{openrazer_driver_package}
+Requires:       python3
 %if 0%{?suse_version}
-Requires: dbus-1-python3
-Requires: typelib(Gdk) = 3.0
+Requires:       dbus-1-python3
+Requires:       typelib(Gdk) = 3.0
 %else
-Requires: python3-dbus
+Requires:       python3-dbus
 %endif
 %if 0%{?mageia}
-Requires: python3-gobject3
+Requires:       python3-gobject3
 %else
-Requires: python3-gobject
+Requires:       python3-gobject
 %endif
-Requires: python3-setproctitle
-Requires: python3-pyudev
-Requires: python3-daemonize
-Requires: xautomation
+Requires:       python3-setproctitle
+Requires:       python3-pyudev
+Requires:       python3-daemonize
+Requires:       xautomation
+Requires:       udev
+%if 0%{?suse_version}
+Requires(pre):  shadow
+%else
+Requires(pre):  shadow-utils
+%endif
 
 %description -n openrazer-daemon
 Userspace daemon that abstracts access to the kernel driver. Provides a DBus service for applications to use.
 
 
 %package -n python3-openrazer
-Summary: OpenRazer Python library
-Group: System Environment/Libraries
-Obsoletes: python3-razer
-Provides: python3-razer
-BuildRequires: python3-devel
-BuildRequires: python3-setuptools
-Requires: openrazer-daemon
-Requires: python3
+Summary:        OpenRazer Python library
+Group:          System Environment/Libraries
+BuildArch:      noarch
+Obsoletes:      python3-razer
+Provides:       python3-razer
+Requires:       openrazer-daemon
+Requires:       python3
 %if 0%{?suse_version}
-Requires: dbus-1-python3
+Requires:       dbus-1-python3
 %else
-Requires: python3-dbus
+Requires:       python3-dbus
 %endif
 %if 0%{?mageia}
-Requires: python3-gobject3
+Requires:       python3-gobject3
 %else
-Requires: python3-gobject
+Requires:       python3-gobject
 %endif
-Requires: python3-numpy
-
+Requires:       python3-numpy
 %description -n python3-openrazer
 Python library for accessing the daemon from Python.
-
 
 %prep
 %if 0%{?gitcommit:1}
@@ -110,32 +159,60 @@ Python library for accessing the daemon from Python.
 %autosetup -n openrazer-%{version}
 %endif
 
+%if %{with openrazer_kmp}
+set -- driver/*
+mkdir source
+mv "$@" source/
+mkdir obj
+%endif
+
 %build
 # noop
 
+%if %{with openrazer_kmp}
+for flavor in %{flavors_to_build}; do
+	rm -rf obj/$flavor
+	cp -r source obj/$flavor
+	make V=1 %{?_smp_mflags} -C %{kernel_source $flavor} %{?linux_make_arch} modules M=$PWD/obj/$flavor
+done
+%endif
 
 %install
-rm -rf $RPM_BUILD_ROOT
 # setup_dkms & udev_install -> razer-kernel-modules-dkms
 # daemon_install -> razer_daemon
 # python_library_install -> python3-razer
-make DESTDIR=$RPM_BUILD_ROOT setup_dkms udev_install daemon_install python_library_install
+make DESTDIR=$RPM_BUILD_ROOT \
+    %if %{without openrazer_kmp}
+    setup_dkms \
+    %endif
+    udev_install \
+    daemon_install \
+    python_library_install
 
+%if %{with openrazer_kmp}
+export INSTALL_MOD_PATH=%{buildroot}
+export INSTALL_MOD_DIR='%{kernel_module_package_moddir}'
+for flavor in %{flavors_to_build}; do
+	make V=1 -C %{kernel_source $flavor} modules_install M=$PWD/obj/$flavor
+done
+
+export BRP_PESIGN_FILES='*.ko'
+%endif
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
-
-%pre -n openrazer-kernel-modules-dkms
+%pre -n openrazer-daemon
 #!/bin/sh
 set -e
-
 getent group plugdev >/dev/null || groupadd -r plugdev
 
+%if %{without openrazer_kmp}
 
 %if 0%{?mageia}
 
 %post -n openrazer-kernel-modules-dkms
+if [ ! -e /.buildenv ] ; then
 dkms add -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
 dkms build -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
 dkms install -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
@@ -145,9 +222,12 @@ echo -e "\e[31m* To complete installation, please run:    *"
 echo -e "\e[31m* # sudo gpasswd -a <yourUsername> plugdev *"
 echo -e "\e[31m********************************************"
 echo -e -n "\e[39m"
+fi
 
 %preun -n openrazer-kernel-modules-dkms
+if [ ! -e /.buildenv ] ; then
 dkms remove -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade --all
+fi
 
 %else
 
@@ -155,6 +235,7 @@ dkms remove -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade --all
 #!/bin/sh
 set -e
 
+if [ ! -e /.buildenv ] ; then
 dkms install %{dkms_name}/%{dkms_version}
 
 echo -e "\e[31m********************************************"
@@ -162,29 +243,30 @@ echo -e "\e[31m* To complete installation, please run:    *"
 echo -e "\e[31m* # sudo gpasswd -a <yourUsername> plugdev *"
 echo -e "\e[31m********************************************"
 echo -e -n "\e[39m"
+fi
 
 %preun -n openrazer-kernel-modules-dkms
 #!/bin/sh
 
+if [ ! -e /.buildenv ] ; then
 if [ "$(dkms status -m %{dkms_name} -v %{dkms_version})" ]; then
   dkms remove -m %{dkms_name} -v %{dkms_version} --all
+fi
 fi
 
 %endif
 
-
-%files
-# meta package is empty
-
-
 %files -n openrazer-kernel-modules-dkms
 %defattr(-,root,root,-)
+%{_usrsrc}/%{dkms_name}-%{dkms_version}/
+
+%endif
+
+%files -n openrazer-daemon
 # A bit hacky but it works
 %{_udevrulesdir}/../razer_mount
 %{_udevrulesdir}/99-razer.rules
-%{_usrsrc}/%{dkms_name}-%{dkms_version}/
-
-%files -n openrazer-daemon
+#
 %{_bindir}/openrazer-daemon
 %{python3_sitelib}/openrazer_daemon/
 %{python3_sitelib}/openrazer_daemon-*.egg-info/
@@ -194,6 +276,11 @@ fi
 %{_mandir}/man5/razer.conf.5*
 %{_mandir}/man8/openrazer-daemon.8*
 
+%files -n openrazer-meta
+# meta package is empty
+
 %files -n python3-openrazer
 %{python3_sitelib}/openrazer/
 %{python3_sitelib}/openrazer-*.egg-info/
+
+%changelog

--- a/preamble
+++ b/preamble
@@ -1,3 +1,4 @@
 Requires:       kernel-%1
 Requires:       openrazer-udev = %{version}
 Conflicts:      openrazer-kernel-modules-dkms
+Provides:      openrazer-driver

--- a/preamble
+++ b/preamble
@@ -1,0 +1,2 @@
+Requires: kernel-%1
+Conflicts: openrazer-kernel-modules-dkms

--- a/preamble
+++ b/preamble
@@ -1,2 +1,3 @@
-Requires: kernel-%1
-Conflicts: openrazer-kernel-modules-dkms
+Requires:       kernel-%1
+Requires:       openrazer-udev = %{version}
+Conflicts:      openrazer-kernel-modules-dkms


### PR DESCRIPTION
A while ago i promised a KMP port for openSUSE so we do not need build
tools on the user machines.

While I did this i did some cleanup to the spec file

A more readable diff might be:

`diff -urwN {hardware:razer,home:darix:playground}/openrazer/openrazer.spec`

1. renaming main package to openrazer because the kmp packages are named <name of main pkg>-kmp
   and the main package needs to be an arch specific package so the kmp
   macros work.  So I move the meta package to a subpackage and marked the
   subpackage noarch. The 2 python packages are marked noarch for the same
   reason now.

2. which handling of the kernel module is being used is decided with the
   conditional on top. to keep the configuration in one place, I also
   defined a variable in the same place for the driver package

   so if you want to build a dkms version for opensuse:

   `osc build --without=openrazer_kmp openSUSE_Tumbleweed`

   In theory you could do a kmp build on non opensuse distros but this should just fail.

3. moved the udev rules and related handling to the daemon subpackage
   I think it makes more sense to have that here or can there be a valid
   use case where you want the driver but not at least the openrazer-daemon?

   If there is such an use case then we should probably move the udev
   rules + user handling into a subpackage like openrazer-udev so that
   the dkms and kmp can Requires it.

4. generic cleanup
   1. BuildRequires can work in subpackages but it is usually preferred
      to have them all on the main package
   2. only run the the dkms test build if we are not in the OBS build
      env. Or do you prefer having it run all the time to make sure it
      works?  I also fixed the requires for the dkms/make package and
      added a longer comment on why they are needed
   3. more consistent indenting in the preambles

This fixes issue #2.