### PR TITLE
Replace %post with %posttrans to fix driver installation

### DIFF
--- a/openrazer.spec
+++ b/openrazer.spec
@@ -135,7 +135,7 @@ getent group plugdev >/dev/null || groupadd -r plugdev
 
 %if 0%{?mageia}
 
-%post -n openrazer-kernel-modules-dkms
+%posttrans -n openrazer-kernel-modules-dkms
 dkms add -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
 dkms build -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
 dkms install -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade
@@ -151,7 +151,7 @@ dkms remove -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade --all
 
 %else
 
-%post -n openrazer-kernel-modules-dkms
+%posttrans -n openrazer-kernel-modules-dkms
 #!/bin/sh
 set -e
 


### PR DESCRIPTION
Currently, driver installation during updates is handled in the %post section of the spec file.
However, according to RPM specification %post is called **before** %preun, causing the driver to be instantly uninstalled by %preun after it has been installed by %post during updates:
https://en.opensuse.org/openSUSE:Packaging_scriptlet_snippets#Scriptlet_Ordering
https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering

By converting %post to %posttrans this issue can be avoided since %posttrans is executed after %preun during a package upgrade but not during actual package uninstallation, allowing the dkms install of the new modules to be performed after the removal of the old modules.

If you have any suggestions for improvement, let me know!