### PR TITLE
spec: Iterate over installed kernels

### DIFF
--- a/openrazer.spec
+++ b/openrazer.spec
@@ -152,10 +152,12 @@ dkms remove -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade --all
 %else
 
 %posttrans -n openrazer-kernel-modules-dkms
-#!/bin/sh
+#!/bin/bash
 set -e
 
-dkms install %{dkms_name}/%{dkms_version}
+for version in $(ls /lib/modules | sort -uV); do
+  dkms install %{dkms_name}/%{dkms_version} -k $version
+done
 
 echo -e "\e[31m********************************************"
 echo -e "\e[31m* To complete installation, please run:    *"


### PR DESCRIPTION
As mentioned on https://github.com/openrazer/openrazer/issues/2177

Makes the post transaction hook use rpm to get kernel versions if rpm is available (like on fedora based distros) and falls back to reading dir names in /lib/modules to get the appropriate kernel version string if rpm is not available (like on openSUSE based distros)